### PR TITLE
Clearer highlight when finding a file

### DIFF
--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -16,16 +16,16 @@
 @text-color-modified: @text-color-warning;
 @text-color-removed: @text-color-error;
 
+@app-background-color: #1e1e1e;
+
 @background-color-info: #537ca0;
 @background-color-success: #9fa84a;
 @background-color-warning: #d57734;
 @background-color-error: #bf4040;
 @background-color-highlight: rgba(255, 255, 255, 0.07);
-@background-color-selected: #262626;
+@background-color-selected: @app-background-color;
 
 @tree-background-color: #262626;
-
-@app-background-color: #1e1e1e;
 
 @base-background-color: lighten(@tool-panel-background-color, 5%);
 @base-border-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Using the fuzzy finder (cmd-T) it's tough to tell which row is selected and which isn't...the background colors are almost the same. This update just makes the selected row a little darker so it stands out.
