### PR TITLE
Add colours in find-and-replace buttons

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,6 +1,7 @@
 @import "stylesheets/atom";
 @import "stylesheets/buttons";
 @import "stylesheets/editor";
+@import "stylesheets/find-and-replace";
 @import "stylesheets/git";
 @import "stylesheets/lists";
 @import "stylesheets/messages";

--- a/stylesheets/find-and-replace.less
+++ b/stylesheets/find-and-replace.less
@@ -1,0 +1,8 @@
+.btn-group-find, .btn-group-replace, .btn-group-replace-all {
+  .btn {
+    color: #66cccc;
+    &:hover {
+      color: #f2f0ec;
+    }
+  }
+}


### PR DESCRIPTION
This will match the same colours used in SublimeText theme.
The buttons are rendered in blue and the options white / gray (active / inactive):

![screen shot 2014-03-19 at 14 33 51](https://f.cloud.github.com/assets/33835/2460506/695d3bb2-af6b-11e3-8a50-e4f937384ac1.png)
