### PR TITLE
Adds git-diff gutter colors

### DIFF
--- a/index.less
+++ b/index.less
@@ -4,6 +4,7 @@
 @import "stylesheets/find-and-replace";
 @import "stylesheets/git";
 @import "stylesheets/highlight-selected";
+@import "stylesheets/git-diff";
 @import "stylesheets/lists";
 @import "stylesheets/messages";
 @import "stylesheets/nav";

--- a/stylesheets/git-diff.less
+++ b/stylesheets/git-diff.less
@@ -1,0 +1,14 @@
+@import "ui-mixins";
+@import "ui-variables";
+
+.editor .gutter .line-number {
+  &.git-line-modified {
+    border-left: 2px solid @0D;
+  }
+  &.git-line-added {
+    border-left: 2px solid @0B;
+  }
+  &.git-line-removed {
+    border-left: 2px solid @08;
+  }
+}


### PR DESCRIPTION
This will make the [git-diff](https://github.com/atom/git-diff) gutter colors to match with the theme.
