### PR TITLE
Updates find and replace preview pane

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 
 * {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .workspace {

--- a/stylesheets/find-and-replace.less
+++ b/stylesheets/find-and-replace.less
@@ -1,8 +1,15 @@
 .btn-group-find, .btn-group-replace, .btn-group-replace-all {
   .btn {
-    color: #66cccc;
+    color: @0C;
     &:hover {
-      color: #f2f0ec;
+      color: @07;
     }
   }
+}
+
+.project-find .highlight-info {
+  color: @0A;
+  background-color: @-00;
+  border-radius: 2px;
+  padding: 3px 1px;
 }

--- a/stylesheets/panes.less
+++ b/stylesheets/panes.less
@@ -10,7 +10,13 @@
 
 .panes {
   .pane {
-    background-color: lighten(@app-background-color, 4%);
+    background-color: @editor-background-color;
+
+    .item-views .pane-item {
+      background-color: @editor-background-color;
+      font-family: @font-family-code;
+      font-size: @font-size;
+    }
 
     &:focus {
       background-color: @app-background-color;
@@ -25,5 +31,33 @@
   .pane-column > * {
     border-bottom: 1px solid @pane-item-border-color;
     &:last-child { border-bottom: none; }
+  }
+}
+
+.preview-pane {
+  .list-tree li.list-nested-item > .list-item {
+    color: @05;
+  }
+
+  .list-tree li:not(.list-nested-item) {
+    color: @05;
+  }
+
+  .highlight-info {
+    color: @05;
+    background-color: @00;
+    border: 1px solid @0A;
+    border-radius: 3px;
+    padding: 2px 1px;
+  }
+  .preview-count {
+    .highlight-info {
+      color: @0A;
+      background-color: @00;
+      border: none;
+    }
+  }
+  .results-view .line-number {
+    color: @09;
   }
 }


### PR DESCRIPTION
After a successful find and replace (when it finds any results) there is a preview, there are minor changes when comparing to sublime, there is a yellow outline instead of the white.

Here is the result:
![find and replace preview pane](https://f.cloud.github.com/assets/33835/2489019/defd0d2e-b151-11e3-81a5-7872fe757956.png)
