### PR TITLE
UI styles are overriding syntax styles

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -7,7 +7,6 @@
 }
 
 .editor {
-  background-color: @editor-background-color;
   font-family: @font-family-code;
 
   &.mini {
@@ -31,12 +30,6 @@
     -webkit-animation-name: highlight;
     -webkit-animation-duration: 1s;
     -webkit-animation-iteration-count: 1;
-  }
-
-  .gutter {
-    color: @text-color-subtle;
-    background-color: @editor-background-color;
-    border-right-color: transparent;
   }
 
 }


### PR DESCRIPTION
I wanted to use the Spacegray Eighties UI with a syntax from another scheme, except the Spacegray UI theme is overriding the background colors of the editor and line numbers.

What it should look like

![screen shot 2014-05-07 at 8 59 22 pm](https://cloud.githubusercontent.com/assets/54012/2911741/47aa78ba-d665-11e3-94f2-8e568f994d19.png)

What it does look like

![screen shot 2014-05-07 at 8 59 57 pm](https://cloud.githubusercontent.com/assets/54012/2911748/5f99f23e-d665-11e3-99e5-96992e36d315.png)

@emilyemorehouse
